### PR TITLE
fix(issue template): drop Tachiyomi references

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -95,6 +95,8 @@ body:
           required: true
         - label: If this is an issue with an official anime extension, I should be opening an issue in the [extensions repository](https://github.com/aniyomiorg/aniyomi-extensions/issues/new/choose).
           required: true
+        - label: If this is an issue with a manga extension, report it to the manga source extension project you added it from.
+          required: true
         - label: I have gone through the [FAQ](https://aniyomi.org/docs/faq/general) and [troubleshooting guide](https://aniyomi.org/docs/guides/troubleshooting/).
           required: true
         - label: I have updated the app to version **[0.15.3.0](https://github.com/aniyomiorg/aniyomi/releases/latest)**.


### PR DESCRIPTION
Tachiyomi no longer exists.

The extension notice in the list point before the removed one remains.