### PR TITLE
MAL: Remove fixed status assignment when adding anime to tracker

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -120,7 +120,6 @@ class MyAnimeList(id: Long) :
     }
 
     private suspend fun add(track: AnimeTrack): AnimeTrack {
-        track.score = 0.0
         return api.updateItem(track)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -15,7 +15,6 @@ import eu.kanade.tachiyomi.data.track.model.MangaTrackSearch
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -120,7 +120,6 @@ class MyAnimeList(id: Long) :
     }
 
     private suspend fun add(track: AnimeTrack): AnimeTrack {
-        track.status = WATCHING
         track.score = 0.0
         return api.updateItem(track)
     }


### PR DESCRIPTION
When adding a new anime to the tracker, the status is always set to ‘watching’, overriding the intended assignment logic:

https://github.com/aniyomiorg/aniyomi/blob/191fea8385bea2112f071c2db5a682662cbd0e44/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt#L206