### PR TITLE
fix: shared download cache

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt
@@ -95,7 +95,7 @@ class AnimeDownloadCache(
         .stateIn(scope, SharingStarted.WhileSubscribed(), false)
 
     private val diskCacheFile: File
-        get() = File(context.cacheDir, "dl_index_cache_v3")
+        get() = File(context.cacheDir, "dl_anime_index_cache_v3")
 
     private val rootDownloadsDirMutex = Mutex()
     private var rootDownloadsDir = RootDirectory(storageManager.getDownloadsDirectory())


### PR DESCRIPTION
Closes #2136

The cache shared between anime and manga is overwritten and filtered by the extension name, so if the anime cache is written first and the cache invalidation time has not yet been reached, the manga cache will not have the same cache extension names loaded, so it will not be possible to verify downloads correctly.

SourceId is null, so mapNotNull will remove the manga extension directory, as sourceMap is from the anime extensions.
https://github.com/aniyomiorg/aniyomi/blob/28fb9367885698b7287bc991f7f65ff70463a39f/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt#L359

sourceMap: Manga
https://github.com/aniyomiorg/aniyomi/blob/28fb9367885698b7287bc991f7f65ff70463a39f/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadCache.kt#L361


Cache loading
Animes
https://github.com/aniyomiorg/aniyomi/blob/28fb9367885698b7287bc991f7f65ff70463a39f/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt#L112

Mangas
https://github.com/aniyomiorg/aniyomi/blob/28fb9367885698b7287bc991f7f65ff70463a39f/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadCache.kt#L112

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
