### PR TITLE
fix: Hosters feature detection

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/EpisodeLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/EpisodeLoader.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.animesource.model.Hoster
 import eu.kanade.tachiyomi.animesource.model.Hoster.Companion.toHosterList
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
+import eu.kanade.tachiyomi.animesource.online.ParsedAnimeHttpSource
 import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadManager
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.HosterState
 import kotlinx.coroutines.CancellationException
@@ -59,7 +60,10 @@ class EpisodeLoader {
         private fun checkHasHosters(source: AnimeHttpSource): Boolean {
             var current: Class<in AnimeHttpSource> = source.javaClass
             while (true) {
-                if (current == AnimeHttpSource::class.java) {
+                if (current == ParsedAnimeHttpSource::class.java ||
+                    current == AnimeHttpSource::class.java ||
+                    current == AnimeSource::class.java
+                ) {
                     return false
                 }
                 if (current.declaredMethods.any {


### PR DESCRIPTION
Add other builtin classes implementing 'hoster' features to detection.

Detection was going down class dependency tree until it finds `AnimeHttpSource`.  
But extensions might also be `ParsedAnimeHttpSource` which implements `hosterListParse` and caused false positive.  
Same goes for `AnimeSource` which implements the `getHosterList` method, and would crash if an extension was inheriting it instead of higher level classes such as `AnimeHttpSource`.

my bad, overlooked these cases since all the exts i tested with were using AnimeHttpSource, observe peak fr*nch engineering

Closes #2213 #2215
(Probably not 2215 fully since hosters bad detection shouldn't crash the app when opening MPV settings ?)