### PR TITLE
Swap left and right double tap key event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
-- Added a description for the horizontal seek gesture setting ([@kenkoro](https://github.com/kenkoro)) ([#2224](https://github.com/aniyomiorg/aniyomi/pull/2224))
+- Added a description for the horizontal seek gesture setting ([@alphastark](https://github.com/alphastark)) ([#2219](https://github.com/aniyomiorg/aniyomi/pull/2219))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 - Added a description for the horizontal seek gesture setting ([@kenkoro](https://github.com/kenkoro)) ([#2224](https://github.com/aniyomiorg/aniyomi/pull/2224))
 
+### Fixed
+
+- Swapped keyEvent listeners for left and right keyboard arrow keys as they were swapped in the code causing the opposite of the desired behavior([@JDKamalakar](https://github.com/JDKamalakar)) ([#1947](https://github.com/aniyomiorg/aniyomi/issues/1947))
+
 ## [v0.18.1.2] - 2025-10-28
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
-- Added a description for the horizontal seek gesture setting ([@alphastark](https://github.com/alphastark)) ([#2219](https://github.com/aniyomiorg/aniyomi/pull/2219))
+- Added a description for the horizontal seek gesture setting ([@kenkoro](https://github.com/kenkoro)) ([#2224](https://github.com/aniyomiorg/aniyomi/pull/2224))
 
 ### Fixed
 
-- Swapped keyEvent listeners for left and right keyboard arrow keys as they were swapped in the code causing the opposite of the desired behavior([@JDKamalakar](https://github.com/JDKamalakar)) ([#1947](https://github.com/aniyomiorg/aniyomi/issues/1947))
+- Swapped keyEvent listeners for left and right keyboard arrow keys as they were swapped in the code causing the opposite of the desired behavior([@alphastark](https://github.com/alphastark)) ([#2219](https://github.com/aniyomiorg/aniyomi/issues/2219))
 
 ## [v0.18.1.2] - 2025-10-28
 ### Fixed

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -848,8 +848,8 @@ class PlayerActivity : BaseActivity() {
                 viewModel.changeVolumeBy(-1)
                 viewModel.displayVolumeSlider()
             }
-            KeyEvent.KEYCODE_DPAD_RIGHT -> viewModel.handleLeftDoubleTap()
-            KeyEvent.KEYCODE_DPAD_LEFT -> viewModel.handleRightDoubleTap()
+            KeyEvent.KEYCODE_DPAD_LEFT -> viewModel.handleLeftDoubleTap()
+            KeyEvent.KEYCODE_DPAD_RIGHT -> viewModel.handleRightDoubleTap()
             KeyEvent.KEYCODE_SPACE -> viewModel.pauseUnpause()
             KeyEvent.KEYCODE_MEDIA_STOP -> finishAndRemoveTask()
 


### PR DESCRIPTION
Swap left and right double tap key event handlers for left and right keyboard arrow keys.


  Swapped keyEvent listeners for left and right keyboard arrow keys as they were swapped in the code causing the opposite of the desired behavior.
  Fixes issue #1947 

