### PR TITLE
fix: Remove duplicate search results in settings

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -234,6 +233,7 @@ private fun SearchResult(
             }
             .take(10) // Just take top 10 result for quicker result
             .toList()
+            .distinctBy { "${it.route::class.java.name}-${it.title}-${it.breadcrumbs}" }
     }
 
     Crossfade(
@@ -254,7 +254,9 @@ private fun SearchResult(
                 ) {
                     items(
                         items = it,
-                        key = { i -> i.hashCode() },
+                        key = { i ->
+                            "${i.route::class.java.name}-${i.title.ifEmpty { "_" }}-${i.breadcrumbs.ifEmpty { "_" }}"
+                        },
                     ) { item ->
                         Column(
                             modifier = Modifier


### PR DESCRIPTION
Removes duplicate entries from the settings search results by using `distinctBy` and updating the item key to be more unique.
