### PR TITLE
fix aniskip toast crash in nonenglish languages

### DIFF
--- a/i18n-aniyomi/src/commonMain/moko-resources/as/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/as/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">স্বয়ংক্ৰিয় চলন সক্ৰিয়</string>
     <string name="disable_auto_play">স্বয়ংক্ৰিয় চলন অক্ষম</string>
     <string name="player_aniskip_dontskip">এৰি নিদিব</string>
-    <string name="player_aniskip_dontskip_toast">%d ছেকেণ্ডত %s এৰি দিয়া হ’ব</string>
+    <string name="player_aniskip_dontskip_toast">%s ৰ %d ছেকেণ্ডত এৰি দিয়া হ’ব</string>
     <string name="player_aniskip_skip">%s এৰি দিয়া হৈছে</string>
     <string name="no_next_episode">পৰৱৰ্তী পৰ্ব পোৱা নগ’ল!</string>
     <string name="no_prev_episode">আগৰ পৰ্ব পোৱা নগ’ল!</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ca/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ca/strings.xml
@@ -58,7 +58,7 @@
     <string name="enable_auto_play">Reproducció automàtica activada</string>
     <string name="disable_auto_play">Reproducció automàtica desactivada</string>
     <string name="player_aniskip_dontskip">No saltar</string>
-    <string name="player_aniskip_dontskip_toast">Salta en %d segons</string>
+    <string name="player_aniskip_dontskip_toast">Salta %s en %d segons</string>
     <string name="player_aniskip_skip">%s saltats</string>
     <string name="no_next_episode">No s\'ha trobat el següent episodi!</string>
     <string name="player_hwdec_mode">Establir per defecte el mode decodificació per hardware</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/de/strings.xml
@@ -110,7 +110,7 @@
     <string name="enable_auto_play">Automatische Wiedergabe ist an</string>
     <string name="disable_auto_play">Automatische Wiedergabe ist aus</string>
     <string name="player_aniskip_dontskip">Nicht überspringen</string>
-    <string name="player_aniskip_dontskip_toast">Wird in %d Sekunden übersprungen</string>
+    <string name="player_aniskip_dontskip_toast">%s wird in %d Sekunden übersprungen</string>
     <string name="player_aniskip_skip">%s übersprungen</string>
     <string name="no_next_episode">Nächste Folge nicht gefunden!</string>
     <string name="player_hwdec_mode">Standard Hardware-Dekodierung wählen</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/fa/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/fa/strings.xml
@@ -46,7 +46,7 @@
     <string name="enable_auto_play">پخش خودکار فعال است</string>
     <string name="disable_auto_play">پخش خودکار فعال نیست</string>
     <string name="player_aniskip_dontskip">گذر نکن</string>
-    <string name="player_aniskip_dontskip_toast">گذر در %d ثانیه</string>
+    <string name="player_aniskip_dontskip_toast">گذر از %s در %d ثانیه</string>
     <string name="player_aniskip_skip">%s گذشت شد</string>
     <string name="no_next_episode">قسمت‌ بعدی پیدا نشد!</string>
     <string name="player_hwdec_mode">تنظیم حالت پیشفرض رمزگشایی سخت افزاری</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/he/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/he/strings.xml
@@ -49,7 +49,7 @@
     <string name="enable_auto_play">נגינה אוטומטית מופעלת</string>
     <string name="disable_auto_play">נגינה אוטומטית כבויה</string>
     <string name="player_aniskip_dontskip">אל תדלג</string>
-    <string name="player_aniskip_dontskip_toast">דלג בעוד %d שניות</string>
+    <string name="player_aniskip_dontskip_toast">דלג %s בעוד %d שניות</string>
     <string name="player_aniskip_skip">%s דולג</string>
     <string name="no_next_episode">הפרק הבא לא נמצא!</string>
     <string name="player_hwdec_mode">הגדר מצב פענוח חומרה ברירת מחדל</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ko/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ko/strings.xml
@@ -64,7 +64,7 @@
     <string name="enable_auto_play">자동 재생 사용 중</string>
     <string name="disable_auto_play">자동 재생이 사용 중지됨</string>
     <string name="player_aniskip_dontskip">건너뛰지 않기</string>
-    <string name="player_aniskip_dontskip_toast">%d초 후에 건너뛰기</string>
+    <string name="player_aniskip_dontskip_toast">%s을(를) %d초 후에 건너뛰기</string>
     <string name="player_aniskip_skip">%s 건너뜀</string>
     <string name="no_next_episode">다음 에피소드를 찾을 수 없습니다!</string>
     <string name="player_hwdec_mode">기본 하드웨어 디코딩 모드 설정</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ta/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ta/strings.xml
@@ -111,7 +111,7 @@
     <string name="enable_auto_play">ஆட்டோ-பிளே இயக்கத்தில் உள்ளது</string>
     <string name="disable_auto_play">ஆட்டோ-பிளே முடக்கப்பட்டுள்ளது</string>
     <string name="player_aniskip_dontskip">தவிர்க்க வேண்டாம்</string>
-    <string name="player_aniskip_dontskip_toast">%d வினாடிகளில் தவிர்க்கவும்</string>
+    <string name="player_aniskip_dontskip_toast">%s ஐ %d வினாடிகளில் தவிர்க்கவும்</string>
     <string name="player_aniskip_skip">%s தவிர்க்கப்பட்டன</string>
     <string name="no_next_episode">அடுத்த அத்தியாயம் கிடைக்கவில்லை!</string>
     <string name="player_hwdec_mode">வன்பொருள் டிகோடிங் பயன்முறை</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/vi/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/vi/strings.xml
@@ -67,7 +67,7 @@
     <string name="enable_auto_play">Tự động phát đang bật</string>
     <string name="disable_auto_play">Tự động phát đang tắt</string>
     <string name="player_aniskip_dontskip">Không skip</string>
-    <string name="player_aniskip_dontskip_toast">Skip sau %d giây</string>
+    <string name="player_aniskip_dontskip_toast">Skip %s sau %d giây</string>
     <string name="player_aniskip_skip">bỏ qua %s giây</string>
     <string name="no_next_episode">Không tìm thấy tập tiếp theo!</string>
     <string name="player_hwdec_mode">Chế độ giải mã phần cứng</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">自动连播已开启</string>
     <string name="disable_auto_play">自动连播已关闭</string>
     <string name="player_aniskip_dontskip">不跳过</string>
-    <string name="player_aniskip_dontskip_toast">将在 %d 秒内跳过 %s</string>
+    <string name="player_aniskip_dontskip_toast">%s 将在 %d 秒内跳过</string>
     <string name="player_aniskip_skip">已跳过 %s</string>
     <string name="no_next_episode">没有下一集！</string>
     <string name="no_prev_episode">未找到上一集！</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -67,7 +67,7 @@
     <string name="enable_auto_play">自動播放已開啟</string>
     <string name="disable_auto_play">自動播放已關閉</string>
     <string name="player_aniskip_dontskip">不要跳過</string>
-    <string name="player_aniskip_dontskip_toast">%d 秒後跳過</string>
+    <string name="player_aniskip_dontskip_toast">跳過 %s 在 %d 秒後</string>
     <string name="player_aniskip_skip">%s 已跳過</string>
     <string name="no_next_episode">未找到下一集！</string>
     <string name="player_hwdec_mode">硬體解碼模式</string>


### PR DESCRIPTION
this is a fix for aniskip toast popups, it would crash on some non-english languages, bcs it expects %s, %d, but for some said languages, it only used %d, this fixes that

refers to this error
App ID: xyz.jmir.tachiyomi.mi
App version: 0.18.1.2 (39e9a74, 131, 2025-10-28T21:49:57Z)
Android version: 13 (SDK 33; build TKQ1.221114.001 test-keys)
Android build ID: TKQ1.221114.001 test-keys
Device brand: Redmi
Device manufacturer: Xiaomi
Device name: veux (veux_global)
Device model: 2201116SG
WebView: Android System WebView 141.0.7390.122
Current time: 2025-10-31T10:29:50.628887+02:00
MPV version: 6764488
Libplacebo version: v7.349.0
FFmpeg version: n7.1

--------- beginning of crash
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: FATAL EXCEPTION: main
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: Process: xyz.jmir.tachiyomi.mi, PID: 32365
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: java.util.IllegalFormatConversionException: d != java.lang.String
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4608)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:3123)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.util.Formatter$FormatSpecifier.print(Formatter.java:3078)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.util.Formatter.format(Formatter.java:2704)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.util.Formatter.format(Formatter.java:2640)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.lang.String.format(String.java:4078)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.content.res.Resources.getString(Resources.java:598)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at tachiyomi.core.common.i18n.LocalizeKt.stringResource(SourceFile:12)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at eu.kanade.tachiyomi.ui.player.PlayerViewModel.setChapter(Unknown Source:133)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at eu.kanade.tachiyomi.ui.player.PlayerObserver$$ExternalSyntheticLambda3.run(Unknown Source:257)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.os.Handler.handleCallback(Handler.java:942)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.os.Handler.dispatchMessage(Handler.java:99)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.os.Looper.loopOnce(Looper.java:211)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.os.Looper.loop(Looper.java:300)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at android.app.ActivityThread.main(ActivityThread.java:8503)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at java.lang.reflect.Method.invoke(Native Method)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:561)
2025-10-31 10:28:48.462 +0200 32365 32365 E AndroidRuntime: at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)