### PR TITLE
Improve library loading speed and UI responsiveness

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryScreenModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -746,6 +747,11 @@ class AnimeLibraryScreenModel(
 
     fun closeDialog() {
         mutableState.update { it.copy(dialog = null) }
+    }
+
+    override fun onDispose() {
+        scopeIO.cancel()
+        super.onDispose()
     }
 
     sealed interface Dialog {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryScreenModel.kt
@@ -410,7 +410,7 @@ class MangaLibraryScreenModel(
     ): MangaLibraryItem = MangaLibraryItem(
         libraryManga,
         downloadCount = if (prefs.downloadBadge) {
-             downloadManager.getDownloadCount(libraryManga.manga).toLong()
+            downloadManager.getDownloadCount(libraryManga.manga).toLong()
         } else {
             0
         },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryScreenModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -731,6 +732,11 @@ class MangaLibraryScreenModel(
 
     fun closeDialog() {
         mutableState.update { it.copy(dialog = null) }
+    }
+
+    override fun onDispose() {
+        scopeIO.cancel()
+        super.onDispose()
     }
 
     sealed interface Dialog {


### PR DESCRIPTION
Local manga and anime requires file system I/O to count downloads, so we process them in parallel to speed up library loading.

I only applied async loading to the local source to avoid creating extra objects in memory if the whole library were loaded async

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
