### PR TITLE
WatchAnime (Forked from Aniyomi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,11 @@
 <div align="center">
 
-<a href="https://aniyomi.org">
-    <img src="./.github/assets/logo.png" alt="Aniyomi logo" title="Aniyomi logo" width="80"/>
-</a>
+# WatchAnime [App](#)
 
-# Aniyomi [App](#)
-
-### Full-featured player and reader, based on ~~Tachiyomi~~ Mihon.
+### Full-featured anime player, forked from [Aniyomi](https://github.com/aniyomiorg/aniyomi).
 Discover and watch anime, cartoons, series, and more – easier than ever on your Android device.
 
-[![Discord server](https://img.shields.io/discord/841701076242530374.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/F32UjdJZrR)
-[![GitHub downloads](https://img.shields.io/github/downloads/aniyomiorg/aniyomi/total?label=downloads&labelColor=27303D&color=0D1117&logo=github&logoColor=FFFFFF&style=flat)](https://github.com/aniyomiorg/aniyomi/releases)
-
-[![CI](https://img.shields.io/github/actions/workflow/status/aniyomiorg/aniyomi/build_push.yml?labelColor=27303D)](https://github.com/aniyomiorg/aniyomi/actions/workflows/build_push.yml)
-[![License: Apache-2.0](https://img.shields.io/github/license/aniyomiorg/aniyomi?labelColor=27303D&color=818cf8)](/LICENSE)
-[![Translation status](https://img.shields.io/weblate/progress/aniyomi?labelColor=27303D&color=946300)](https://hosted.weblate.org/engage/aniyomi/)
-
 ## Download
-
-[![Aniyomi Stable](https://img.shields.io/github/release/aniyomiorg/aniyomi.svg?maxAge=3600&label=Stable&labelColor=06599d&color=043b69)](https://github.com/aniyomiorg/aniyomi/releases)
-[![Aniyomi Preview](https://img.shields.io/github/v/release/aniyomiorg/aniyomi-preview.svg?maxAge=3600&label=Beta&labelColor=2c2c47&color=1c1c39)](https://github.com/aniyomiorg/aniyomi-preview/releases)
 
 *Requires Android 8.0 or higher.*
 
@@ -27,34 +13,26 @@ Discover and watch anime, cartoons, series, and more – easier than ever on you
 
 <div align="left">
 
-* Local reading and watching of content.
-* A configurable reader with multiple viewers, reading directions and other settings.
+* Local watching of content.
 * A configurable player built on mpv-android with multiple options and settings.
-* Tracker support: [MyAnimeList](https://myanimelist.net/), [AniList](https://anilist.co/), [Kitsu](https://kitsu.app/), [MangaUpdates](https://mangaupdates.com), [Shikimori](https://shikimori.one), [Simkl](https://simkl.com/), and [Bangumi](https://bgm.tv/) support.
+* Tracker support: [MyAnimeList](https://myanimelist.net/), [AniList](https://anilist.co/), [Kitsu](https://kitsu.app/), [Shikimori](https://shikimori.one), [Simkl](https://simkl.com/), and [Bangumi](https://bgm.tv/) support.
 * Categories to organize your library.
 * Light and dark themes.
-* Schedule updating your library for new chapters/episodes.
-* Create backups locally to read/watch offline or to your desired cloud service.
+* Schedule updating your library for new episodes.
+* Create backups locally to watch offline or to your desired cloud service.
 * Plus much more...
 
 </div>
 
 ## Contributing
 
-[Code of conduct](./CODE_OF_CONDUCT.md) · [Contributing guide](./CONTRIBUTING.md)
-
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
-
-Before reporting a new issue, take a look at the [FAQ](https://aniyomi.org/docs/faq/general), the [changelog](https://aniyomi.org/changelogs/) and the already opened [issues](https://github.com/aniyomiorg/aniyomi/issues); if you got any questions, join our [Discord server](https://discord.gg/F32UjdJZrR).
-
-### Repositories
-
-[![aniyomiorg/aniyomi-website - GitHub](https://github-readme-stats.vercel.app/api/pin/?username=aniyomiorg&repo=aniyomi-website&bg_color=161B22&text_color=c9d1d9&title_color=818cf8&icon_color=818cf8&border_radius=8&hide_border=true&description_lines_count=2)](https://github.com/aniyomiorg/aniyomi-website/)
-[![aniyomiorg/aniyomi-mpv-lib - GitHub](https://github-readme-stats.vercel.app/api/pin/?username=aniyomiorg&repo=aniyomi-mpv-lib&bg_color=161B22&text_color=c9d1d9&title_color=818cf8&icon_color=818cf8&border_radius=8&hide_border=true&description_lines_count=2)](https://github.com/aniyomiorg/aniyomi-mpv-lib/)
 
 ### Credits
 
-Thank you to all the people who have contributed!
+This project is forked from [Aniyomi](https://github.com/aniyomiorg/aniyomi), which is based on [Mihon](https://github.com/mihondev/mihon) (formerly Tachiyomi).
+
+Thank you to all the people who have contributed to Aniyomi!
 
 <a href="https://github.com/aniyomiorg/aniyomi/graphs/contributors">
     <img src="https://contrib.rocks/image?repo=aniyomiorg/aniyomi" alt="Aniyomi app contributors" title="Aniyomi app contributors" width="800"/>

--- a/app/src/main/java/eu/kanade/domain/ui/model/NavStyle.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/NavStyle.kt
@@ -1,7 +1,6 @@
 package eu.kanade.domain.ui.model
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.CollectionsBookmark
 import androidx.compose.material.icons.outlined.Explore
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.runtime.Composable
@@ -13,7 +12,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.browse.BrowseTab
 import eu.kanade.tachiyomi.ui.history.HistoriesTab
 import eu.kanade.tachiyomi.ui.library.anime.AnimeLibraryTab
-import eu.kanade.tachiyomi.ui.library.manga.MangaLibraryTab
 import eu.kanade.tachiyomi.ui.more.MoreTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
 import tachiyomi.i18n.aniyomi.AYMR
@@ -22,7 +20,6 @@ enum class NavStyle(
     val titleRes: StringResource,
     val moreTab: Tab,
 ) {
-    MOVE_MANGA_TO_MORE(titleRes = AYMR.strings.pref_bottom_nav_no_manga, moreTab = MangaLibraryTab),
     MOVE_UPDATES_TO_MORE(titleRes = AYMR.strings.pref_bottom_nav_no_updates, moreTab = UpdatesTab),
     MOVE_HISTORY_TO_MORE(titleRes = AYMR.strings.pref_bottom_nav_no_history, moreTab = HistoriesTab),
     MOVE_BROWSE_TO_MORE(titleRes = AYMR.strings.pref_bottom_nav_no_browse, moreTab = BrowseTab),
@@ -31,7 +28,6 @@ enum class NavStyle(
     val moreIcon: ImageVector
         @Composable
         get() = when (this) {
-            MOVE_MANGA_TO_MORE -> Icons.Outlined.CollectionsBookmark
             MOVE_UPDATES_TO_MORE -> ImageVector.vectorResource(id = R.drawable.ic_updates_outline_24dp)
             MOVE_HISTORY_TO_MORE -> Icons.Outlined.History
             MOVE_BROWSE_TO_MORE -> Icons.Outlined.Explore
@@ -41,7 +37,6 @@ enum class NavStyle(
         get() {
             return mutableListOf(
                 AnimeLibraryTab,
-                MangaLibraryTab,
                 UpdatesTab,
                 HistoriesTab,
                 BrowseTab,

--- a/app/src/main/java/eu/kanade/domain/ui/model/StartScreen.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/StartScreen.kt
@@ -5,14 +5,12 @@ import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.ui.browse.BrowseTab
 import eu.kanade.tachiyomi.ui.history.HistoriesTab
 import eu.kanade.tachiyomi.ui.library.anime.AnimeLibraryTab
-import eu.kanade.tachiyomi.ui.library.manga.MangaLibraryTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
 
 enum class StartScreen(val titleRes: StringResource, val tab: Tab) {
     ANIME(AYMR.strings.label_anime, AnimeLibraryTab),
-    MANGA(AYMR.strings.manga, MangaLibraryTab),
     UPDATES(MR.strings.label_recent_updates, UpdatesTab),
     HISTORY(MR.strings.label_recent_manga, HistoriesTab),
     BROWSE(MR.strings.browse, BrowseTab),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -189,12 +189,6 @@ object SettingsMainScreen : Screen() {
             screen = SettingsLibraryScreen,
         ),
         Item(
-            titleRes = MR.strings.pref_category_reader,
-            subtitleRes = MR.strings.pref_reader_summary,
-            icon = Icons.AutoMirrored.Outlined.ChromeReaderMode,
-            screen = SettingsReaderScreen,
-        ),
-        Item(
             titleRes = AYMR.strings.label_player,
             subtitleRes = AYMR.strings.pref_player_settings_summary,
             icon = Icons.Outlined.VideoSettings,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
@@ -329,7 +329,6 @@ private val playerSettingScreens = listOf(
 private val settingScreens = listOf(
     SettingsAppearanceScreen,
     SettingsLibraryScreen,
-    SettingsReaderScreen,
     SettingsDownloadScreen,
     SettingsTrackingScreen,
     SettingsBrowseScreen,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -21,10 +21,6 @@ import eu.kanade.tachiyomi.ui.browse.anime.extension.animeExtensionsTab
 import eu.kanade.tachiyomi.ui.browse.anime.migration.sources.migrateAnimeSourceTab
 import eu.kanade.tachiyomi.ui.browse.anime.source.animeSourcesTab
 import eu.kanade.tachiyomi.ui.browse.anime.source.globalsearch.GlobalAnimeSearchScreen
-import eu.kanade.tachiyomi.ui.browse.manga.extension.MangaExtensionsScreenModel
-import eu.kanade.tachiyomi.ui.browse.manga.extension.mangaExtensionsTab
-import eu.kanade.tachiyomi.ui.browse.manga.migration.sources.migrateMangaSourceTab
-import eu.kanade.tachiyomi.ui.browse.manga.source.mangaSourcesTab
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.channels.BufferOverflow
@@ -48,7 +44,6 @@ data object BrowseTab : Tab {
             )
         }
 
-    // TODO: Find a way to let it open Global Anime/Manga Search depending on what Tab(e.g. Anime/Manga Source Tab) is open
     override suspend fun onReselect(navigator: Navigator) {
         navigator.push(GlobalAnimeSearchScreen())
     }
@@ -56,31 +51,24 @@ data object BrowseTab : Tab {
     private val switchToTabNumberChannel = Channel<Int>(1, BufferOverflow.DROP_OLDEST)
 
     fun showExtension() {
-        switchToTabNumberChannel.trySend(3) // Manga extensions: tab no. 3
+        switchToTabNumberChannel.trySend(1) // Anime extensions: tab no. 1
     }
 
     fun showAnimeExtension() {
-        switchToTabNumberChannel.trySend(2) // Anime extensions: tab no. 2
+        switchToTabNumberChannel.trySend(1) // Anime extensions: tab no. 1
     }
 
     @Composable
     override fun Content() {
         val context = LocalContext.current
 
-        // Hoisted for extensions tab's search bar
-        val mangaExtensionsScreenModel = rememberScreenModel { MangaExtensionsScreenModel() }
-        val mangaExtensionsState by mangaExtensionsScreenModel.state.collectAsState()
-
         val animeExtensionsScreenModel = rememberScreenModel { AnimeExtensionsScreenModel() }
         val animeExtensionsState by animeExtensionsScreenModel.state.collectAsState()
 
         val tabs = persistentListOf(
             animeSourcesTab(),
-            mangaSourcesTab(),
             animeExtensionsTab(animeExtensionsScreenModel),
-            mangaExtensionsTab(mangaExtensionsScreenModel),
             migrateAnimeSourceTab(),
-            migrateMangaSourceTab(),
         )
 
         val state = rememberPagerState { tabs.size }
@@ -89,8 +77,6 @@ data object BrowseTab : Tab {
             titleRes = MR.strings.browse,
             tabs = tabs,
             state = state,
-            mangaSearchQuery = mangaExtensionsState.searchQuery,
-            onChangeMangaSearchQuery = mangaExtensionsScreenModel::search,
             animeSearchQuery = animeExtensionsState.searchQuery,
             onChangeAnimeSearchQuery = animeExtensionsScreenModel::search,
             scrollable = true,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoriesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoriesTab.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.category
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
@@ -16,16 +15,10 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.category.anime.AnimeCategoryEvent
 import eu.kanade.tachiyomi.ui.category.anime.AnimeCategoryScreenModel
 import eu.kanade.tachiyomi.ui.category.anime.animeCategoryTab
-import eu.kanade.tachiyomi.ui.category.manga.MangaCategoryEvent
-import eu.kanade.tachiyomi.ui.category.manga.MangaCategoryScreenModel
-import eu.kanade.tachiyomi.ui.category.manga.mangaCategoryTab
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.receiveAsFlow
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.i18n.stringResource
 
@@ -43,46 +36,29 @@ data object CategoriesTab : Tab {
             )
         }
 
-    private val switchToMangaCategoryTabChannel = Channel<Unit>(1, BufferOverflow.DROP_OLDEST)
-
-    fun showMangaCategory() {
-        switchToMangaCategoryTabChannel.trySend(Unit)
-    }
+    // No-op: manga categories are no longer accessible but callers still reference this
+    fun showMangaCategory() {}
 
     @Composable
     override fun Content() {
         val context = LocalContext.current
 
         val animeCategoryScreenModel = rememberScreenModel { AnimeCategoryScreenModel() }
-        val mangaCategoryScreenModel = rememberScreenModel { MangaCategoryScreenModel() }
 
         val tabs = persistentListOf(
             animeCategoryTab(),
-            mangaCategoryTab(),
         )
-
-        val state = rememberPagerState { tabs.size }
 
         TabbedScreen(
             titleRes = AYMR.strings.general_categories,
             tabs = tabs,
-            state = state,
         )
-        LaunchedEffect(Unit) {
-            switchToMangaCategoryTabChannel.receiveAsFlow()
-                .collectLatest { state.scrollToPage(1) }
-        }
 
         LaunchedEffect(Unit) {
             (context as? MainActivity)?.ready = true
         }
 
         LaunchedEffect(Unit) {
-            mangaCategoryScreenModel.events.collectLatest { event ->
-                if (event is MangaCategoryEvent.LocalizedMessage) {
-                    context.toast(event.stringRes)
-                }
-            }
             animeCategoryScreenModel.events.collectLatest { event ->
                 if (event is AnimeCategoryEvent.LocalizedMessage) {
                     context.toast(event.stringRes)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadsTab.kt
@@ -7,15 +7,9 @@ import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.filled.PlayArrow
@@ -24,9 +18,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -36,19 +28,16 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -63,16 +52,11 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.download.anime.AnimeDownloadHeaderItem
 import eu.kanade.tachiyomi.ui.download.anime.AnimeDownloadQueueScreenModel
 import eu.kanade.tachiyomi.ui.download.anime.animeDownloadTab
-import eu.kanade.tachiyomi.ui.download.manga.MangaDownloadHeaderItem
-import eu.kanade.tachiyomi.ui.download.manga.MangaDownloadQueueScreenModel
-import eu.kanade.tachiyomi.ui.download.manga.mangaDownloadTab
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.launch
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.components.Pill
 import tachiyomi.presentation.core.components.material.Scaffold
-import tachiyomi.presentation.core.components.material.TabText
 import tachiyomi.presentation.core.i18n.stringResource
 
 data object DownloadsTab : Tab {
@@ -92,25 +76,17 @@ data object DownloadsTab : Tab {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
-        val scope = rememberCoroutineScope()
         val animeScreenModel = rememberScreenModel { AnimeDownloadQueueScreenModel() }
-        val mangaScreenModel = rememberScreenModel { MangaDownloadQueueScreenModel() }
         val animeDownloadList by animeScreenModel.state.collectAsState()
-        val mangaDownloadList by mangaScreenModel.state.collectAsState()
         val animeDownloadCount by remember {
             derivedStateOf { animeDownloadList.sumOf { it.subItems.size } }
         }
-        val mangaDownloadCount by remember {
-            derivedStateOf { mangaDownloadList.sumOf { it.subItems.size } }
-        }
 
-        val state = rememberPagerState { 2 }
         val snackbarHostState = remember { SnackbarHostState() }
 
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
         var fabExpanded by remember { mutableStateOf(true) }
         val nestedScrollConnection = remember {
-            // All this lines just for fab state :/
             object : NestedScrollConnection {
                 override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                     fabExpanded = available.y >= 0
@@ -156,72 +132,40 @@ data object DownloadsTab : Tab {
                     },
                     navigateUp = navigator::pop,
                     actions = {
-                        when (state.currentPage) {
-                            0 -> AnimeActions(animeScreenModel, animeDownloadList)
-                            1 -> MangaActions(mangaScreenModel, mangaDownloadList)
-                        }
+                        AnimeActions(animeScreenModel, animeDownloadList)
                     },
                     scrollBehavior = scrollBehavior,
                 )
             },
             floatingActionButton = {
                 AnimatedVisibility(
-                    visible = when (state.currentPage) {
-                        0 -> animeDownloadList.isNotEmpty()
-                        1 -> mangaDownloadList.isNotEmpty()
-                        else -> false
-                    },
+                    visible = animeDownloadList.isNotEmpty(),
                     enter = fadeIn(),
                     exit = fadeOut(),
                 ) {
                     val animeIsRunning by animeScreenModel.isDownloaderRunning.collectAsState()
-                    val mangaIsRunning by mangaScreenModel.isDownloaderRunning.collectAsState()
                     ExtendedFloatingActionButton(
                         text = {
-                            val id = when (state.currentPage) {
-                                0 -> if (animeIsRunning) {
-                                    AYMR.strings.action_stop
-                                } else {
-                                    AYMR.strings.action_continue
-                                }
-                                1 -> if (mangaIsRunning) {
-                                    MR.strings.action_pause
-                                } else {
-                                    MR.strings.action_resume
-                                }
-                                else -> MR.strings.action_pause
+                            val id = if (animeIsRunning) {
+                                AYMR.strings.action_stop
+                            } else {
+                                AYMR.strings.action_continue
                             }
                             Text(text = stringResource(id))
                         },
                         icon = {
-                            val icon = when (state.currentPage) {
-                                0 -> if (animeIsRunning) {
-                                    Icons.Outlined.Pause
-                                } else {
-                                    Icons.Filled.PlayArrow
-                                }
-                                1 -> if (mangaIsRunning) {
-                                    Icons.Outlined.Pause
-                                } else {
-                                    Icons.Filled.PlayArrow
-                                }
-                                else -> Icons.Filled.PlayArrow
+                            val icon = if (animeIsRunning) {
+                                Icons.Outlined.Pause
+                            } else {
+                                Icons.Filled.PlayArrow
                             }
                             Icon(imageVector = icon, contentDescription = null)
                         },
                         onClick = {
-                            when (state.currentPage) {
-                                0 -> if (animeIsRunning) {
-                                    animeScreenModel.pauseDownloads()
-                                } else {
-                                    animeScreenModel.startDownloads()
-                                }
-
-                                1 -> if (mangaIsRunning) {
-                                    mangaScreenModel.pauseDownloads()
-                                } else {
-                                    mangaScreenModel.startDownloads()
-                                }
+                            if (animeIsRunning) {
+                                animeScreenModel.pauseDownloads()
+                            } else {
+                                animeScreenModel.startDownloads()
                             }
                         },
                         expanded = fabExpanded,
@@ -229,65 +173,15 @@ data object DownloadsTab : Tab {
                 }
             },
         ) { contentPadding ->
-            Column(
-                modifier = Modifier.padding(
+            animeDownloadTab(
+                nestedScrollConnection,
+            ).content(
+                PaddingValues(
                     top = contentPadding.calculateTopPadding(),
-                    start = contentPadding.calculateStartPadding(LocalLayoutDirection.current),
-                    end = contentPadding.calculateEndPadding(LocalLayoutDirection.current),
+                    bottom = contentPadding.calculateBottomPadding(),
                 ),
-            ) {
-                PrimaryTabRow(
-                    selectedTabIndex = state.currentPage,
-                    modifier = Modifier.zIndex(1f),
-                ) {
-                    listOf(
-                        Tab(
-                            selected = state.currentPage == 0,
-                            onClick = { scope.launch { state.animateScrollToPage(0) } },
-                            text = {
-                                TabText(
-                                    text = stringResource(AYMR.strings.label_anime),
-                                    badgeCount = animeDownloadCount,
-                                )
-                            },
-                            unselectedContentColor = MaterialTheme.colorScheme.onSurface,
-                        ),
-                        Tab(
-                            selected = state.currentPage == 1,
-                            onClick = { scope.launch { state.animateScrollToPage(1) } },
-                            text = {
-                                TabText(
-                                    text = stringResource(AYMR.strings.manga),
-                                    badgeCount = mangaDownloadCount,
-                                )
-                            },
-                            unselectedContentColor = MaterialTheme.colorScheme.onSurface,
-                        ),
-                    )
-                }
-
-                HorizontalPager(
-                    modifier = Modifier.fillMaxSize(),
-                    state = state,
-                    verticalAlignment = Alignment.Top,
-                    pageNestedScrollConnection = nestedScrollConnection,
-                ) { page ->
-                    when (page) {
-                        0 -> animeDownloadTab(
-                            nestedScrollConnection,
-                        ).content(
-                            PaddingValues(bottom = contentPadding.calculateBottomPadding()),
-                            snackbarHostState,
-                        )
-                        1 -> mangaDownloadTab(
-                            nestedScrollConnection,
-                        ).content(
-                            PaddingValues(bottom = contentPadding.calculateBottomPadding()),
-                            snackbarHostState,
-                        )
-                    }
-                }
-            }
+                snackbarHostState,
+            )
         }
     }
 
@@ -369,90 +263,6 @@ data object DownloadsTab : Tab {
                     AppBar.OverflowAction(
                         title = stringResource(MR.strings.action_cancel_all),
                         onClick = { animeScreenModel.clearQueue() },
-                    ),
-                ),
-            )
-        }
-    }
-
-    @Composable
-    private fun MangaActions(
-        mangaScreenModel: MangaDownloadQueueScreenModel,
-        mangaDownloadList: List<MangaDownloadHeaderItem>,
-    ) {
-        if (mangaDownloadList.isNotEmpty()) {
-            var sortExpanded by remember { mutableStateOf(false) }
-            val onDismissRequest = { sortExpanded = false }
-            DropdownMenu(
-                expanded = sortExpanded,
-                onDismissRequest = onDismissRequest,
-            ) {
-                NestedMenuItem(
-                    text = { Text(text = stringResource(MR.strings.action_order_by_upload_date)) },
-                    children = { closeMenu ->
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(MR.strings.action_newest)) },
-                            onClick = {
-                                mangaScreenModel.reorderQueue(
-                                    { it.download.chapter.dateUpload },
-                                    true,
-                                )
-                                closeMenu()
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(MR.strings.action_oldest)) },
-                            onClick = {
-                                mangaScreenModel.reorderQueue(
-                                    { it.download.chapter.dateUpload },
-                                    false,
-                                )
-                                closeMenu()
-                            },
-                        )
-                    },
-                )
-                NestedMenuItem(
-                    text = {
-                        Text(
-                            text = stringResource(MR.strings.action_order_by_chapter_number),
-                        )
-                    },
-                    children = { closeMenu ->
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(MR.strings.action_asc)) },
-                            onClick = {
-                                mangaScreenModel.reorderQueue(
-                                    { it.download.chapter.chapterNumber },
-                                    false,
-                                )
-                                closeMenu()
-                            },
-                        )
-                        DropdownMenuItem(
-                            text = { Text(text = stringResource(MR.strings.action_desc)) },
-                            onClick = {
-                                mangaScreenModel.reorderQueue(
-                                    { it.download.chapter.chapterNumber },
-                                    true,
-                                )
-                                closeMenu()
-                            },
-                        )
-                    },
-                )
-            }
-
-            AppBarActions(
-                persistentListOf(
-                    AppBar.Action(
-                        title = stringResource(MR.strings.action_sort),
-                        icon = Icons.AutoMirrored.Outlined.Sort,
-                        onClick = { sortExpanded = true },
-                    ),
-                    AppBar.OverflowAction(
-                        title = stringResource(MR.strings.action_cancel_all),
-                        onClick = { mangaScreenModel.clearQueue() },
                     ),
                 ),
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoriesTab.kt
@@ -19,8 +19,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.history.anime.AnimeHistoryScreenModel
 import eu.kanade.tachiyomi.ui.history.anime.animeHistoryTab
 import eu.kanade.tachiyomi.ui.history.anime.resumeLastEpisodeSeenEvent
-import eu.kanade.tachiyomi.ui.history.manga.MangaHistoryScreenModel
-import eu.kanade.tachiyomi.ui.history.manga.mangaHistoryTab
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
@@ -35,7 +33,7 @@ data object HistoriesTab : Tab {
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_history_enter)
             val index: UShort = when (currentNavigationStyle()) {
                 NavStyle.MOVE_HISTORY_TO_MORE -> 5u
-                NavStyle.MOVE_BROWSE_TO_MORE -> 3u
+                NavStyle.MOVE_BROWSE_TO_MORE -> 2u
                 else -> 2u
             }
             return TabOptions(
@@ -53,9 +51,6 @@ data object HistoriesTab : Tab {
     override fun Content() {
         val context = LocalContext.current
         val fromMore = currentNavigationStyle() == NavStyle.MOVE_HISTORY_TO_MORE
-        // Hoisted for history tab's search bar
-        val mangaHistoryScreenModel = rememberScreenModel { MangaHistoryScreenModel() }
-        val mangaSearchQuery by mangaHistoryScreenModel.query.collectAsState()
 
         val animeHistoryScreenModel = rememberScreenModel { AnimeHistoryScreenModel() }
         val animeSearchQuery by animeHistoryScreenModel.query.collectAsState()
@@ -64,10 +59,7 @@ data object HistoriesTab : Tab {
             titleRes = MR.strings.label_recent_manga,
             tabs = persistentListOf(
                 animeHistoryTab(context, fromMore),
-                mangaHistoryTab(context, fromMore),
             ),
-            mangaSearchQuery = mangaSearchQuery,
-            onChangeMangaSearchQuery = mangaHistoryScreenModel::search,
             animeSearchQuery = animeSearchQuery,
             onChangeAnimeSearchQuery = animeHistoryScreenModel::search,
         )
@@ -77,6 +69,3 @@ data object HistoriesTab : Tab {
         }
     }
 }
-
-private const val TAB_ANIME = 0
-private const val TAB_MANGA = 1

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -41,15 +41,12 @@ import eu.kanade.presentation.util.isTabletUi
 import eu.kanade.tachiyomi.ui.browse.BrowseTab
 import eu.kanade.tachiyomi.ui.download.DownloadsTab
 import eu.kanade.tachiyomi.ui.entries.anime.AnimeScreen
-import eu.kanade.tachiyomi.ui.entries.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.history.HistoriesTab
 import eu.kanade.tachiyomi.ui.library.anime.AnimeLibraryTab
-import eu.kanade.tachiyomi.ui.library.manga.MangaLibraryTab
 import eu.kanade.tachiyomi.ui.more.MoreTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import soup.compose.material.motion.animation.materialFadeThroughIn
@@ -159,27 +156,18 @@ object HomeScreen : Screen() {
                 launch {
                     librarySearchEvent.receiveAsFlow().collectLatest {
                         goToStartScreen()
-                        when (defaultTab) {
-                            AnimeLibraryTab -> AnimeLibraryTab.search(it)
-                            MangaLibraryTab -> MangaLibraryTab.search(it)
-                            else -> {}
-                        }
+                        AnimeLibraryTab.search(it)
                     }
                 }
                 launch {
                     openTabEvent.receiveAsFlow().collectLatest {
                         tabNavigator.current = when (it) {
                             is Tab.AnimeLib -> AnimeLibraryTab
-                            is Tab.Library -> MangaLibraryTab
                             is Tab.Updates -> UpdatesTab
                             is Tab.History -> HistoriesTab
                             is Tab.Browse -> {
                                 if (it.toExtensions) {
-                                    if (!it.anime) {
-                                        BrowseTab.showExtension()
-                                    } else {
-                                        BrowseTab.showAnimeExtension()
-                                    }
+                                    BrowseTab.showAnimeExtension()
                                 }
                                 BrowseTab
                             }
@@ -188,9 +176,6 @@ object HomeScreen : Screen() {
 
                         if (it is Tab.AnimeLib && it.animeIdToOpen != null) {
                             navigator.push(AnimeScreen(it.animeIdToOpen))
-                        }
-                        if (it is Tab.Library && it.mangaIdToOpen != null) {
-                            navigator.push(MangaScreen(it.mangaIdToOpen))
                         }
                         if (it is Tab.More && it.toDownloads) {
                             navigator.push(DownloadsTab)
@@ -265,10 +250,7 @@ object HomeScreen : Screen() {
                     UpdatesTab::class.isInstance(tab) -> {
                         val count by produceState(initialValue = 0) {
                             val pref = Injekt.get<LibraryPreferences>()
-                            combine(
-                                pref.newAnimeUpdatesCount().changes(),
-                                pref.newMangaUpdatesCount().changes(),
-                            ) { countAnime, countManga -> countAnime + countManga }
+                            pref.newAnimeUpdatesCount().changes()
                                 .collectLatest { value = if (pref.newShowUpdatesCount().get()) it else 0 }
                         }
                         if (count > 0) {
@@ -288,10 +270,7 @@ object HomeScreen : Screen() {
                     BrowseTab::class.isInstance(tab) -> {
                         val count by produceState(initialValue = 0) {
                             val pref = Injekt.get<SourcePreferences>()
-                            combine(
-                                pref.mangaExtensionUpdatesCount().changes(),
-                                pref.animeExtensionUpdatesCount().changes(),
-                            ) { extCount, animeExtCount -> extCount + animeExtCount }
+                            pref.animeExtensionUpdatesCount().changes()
                                 .collectLatest { value = it }
                         }
                         if (count > 0) {
@@ -334,7 +313,6 @@ object HomeScreen : Screen() {
 
     sealed interface Tab {
         data class AnimeLib(val animeIdToOpen: Long? = null) : Tab
-        data class Library(val mangaIdToOpen: Long? = null) : Tab
         data object Updates : Tab
         data object History : Tab
         data class Browse(val toExtensions: Boolean = false, val anime: Boolean = false) : Tab

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryTab.kt
@@ -71,7 +71,7 @@ data object MangaLibraryTab : Tab {
     override val options: TabOptions
         @Composable
         get() {
-            val fromMore = currentNavigationStyle() == NavStyle.MOVE_MANGA_TO_MORE
+            val fromMore = currentNavigationStyle() == NavStyle.MOVE_HISTORY_TO_MORE
             val title = AYMR.strings.label_manga_library
             val isSelected = LocalTabNavigator.current.current.key == key
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_library_enter)
@@ -110,7 +110,7 @@ data object MangaLibraryTab : Tab {
             started
         }
 
-        val fromMore = currentNavigationStyle() == NavStyle.MOVE_MANGA_TO_MORE
+        val fromMore = currentNavigationStyle() == NavStyle.MOVE_HISTORY_TO_MORE
 
         val navigateUp: (() -> Unit)? = if (fromMore) {
             {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -463,11 +463,10 @@ class MainActivity : BaseActivity() {
 
         val tabToOpen = when (intent.action) {
             Constants.SHORTCUT_ANIMELIB -> HomeScreen.Tab.AnimeLib()
-            Constants.SHORTCUT_LIBRARY -> HomeScreen.Tab.Library()
+            Constants.SHORTCUT_LIBRARY -> HomeScreen.Tab.AnimeLib()
             Constants.SHORTCUT_MANGA -> {
-                val idToOpen = intent.extras?.getLong(Constants.MANGA_EXTRA) ?: return false
-                navigator.popUntilRoot()
-                HomeScreen.Tab.Library(idToOpen)
+                // Manga shortcuts now redirect to anime library
+                HomeScreen.Tab.AnimeLib()
             }
             Constants.SHORTCUT_ANIME -> {
                 val idToOpen = intent.extras?.getLong(Constants.ANIME_EXTRA) ?: return false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
@@ -22,7 +22,6 @@ import eu.kanade.presentation.more.MoreScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadManager
-import eu.kanade.tachiyomi.data.download.manga.MangaDownloadManager
 import eu.kanade.tachiyomi.ui.category.CategoriesTab
 import eu.kanade.tachiyomi.ui.download.DownloadsTab
 import eu.kanade.tachiyomi.ui.setting.PlayerSettingsScreen
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -86,7 +84,6 @@ data object MoreTab : Tab {
 }
 
 private class MoreScreenModel(
-    private val downloadManager: MangaDownloadManager = Injekt.get(),
     private val animeDownloadManager: AnimeDownloadManager = Injekt.get(),
     preferences: BasePreferences = Injekt.get(),
 ) : ScreenModel {
@@ -100,33 +97,18 @@ private class MoreScreenModel(
     val downloadQueueState: StateFlow<DownloadQueueState> = _downloadQueueState.asStateFlow()
 
     init {
-        // Handle running/paused status change and queue progress updating
         screenModelScope.launchIO {
-            combine(
-                downloadManager.isDownloaderRunning,
-                downloadManager.queueState,
-            ) { isRunningManga, mangaDownloadQueue -> Pair(isRunningManga, mangaDownloadQueue.size) }
-                .collectLatest { (isDownloadingManga, mangaDownloadQueueSize) ->
-                    combine(
-                        animeDownloadManager.isDownloaderRunning,
-                        animeDownloadManager.queueState,
-                    ) { isRunningAnime, animeDownloadQueue ->
-                        Pair(
-                            isRunningAnime,
-                            animeDownloadQueue.size,
-                        )
+            animeDownloadManager.isDownloaderRunning.collectLatest { isRunning ->
+                animeDownloadManager.queueState.collectLatest { queue ->
+                    val downloadQueueSize = queue.size
+                    val pendingDownloadExists = downloadQueueSize != 0
+                    _downloadQueueState.value = when {
+                        !pendingDownloadExists -> DownloadQueueState.Stopped
+                        !isRunning -> DownloadQueueState.Paused(downloadQueueSize)
+                        else -> DownloadQueueState.Downloading(downloadQueueSize)
                     }
-                        .collectLatest { (isDownloadingAnime, animeDownloadQueueSize) ->
-                            val isDownloading = isDownloadingAnime || isDownloadingManga
-                            val downloadQueueSize = mangaDownloadQueueSize + animeDownloadQueueSize
-                            val pendingDownloadExists = downloadQueueSize != 0
-                            _downloadQueueState.value = when {
-                                !pendingDownloadExists -> DownloadQueueState.Stopped
-                                !isDownloading -> DownloadQueueState.Paused(downloadQueueSize)
-                                else -> DownloadQueueState.Downloading(downloadQueueSize)
-                            }
-                        }
                 }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsTab.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.stats
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
@@ -14,7 +13,6 @@ import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.stats.anime.animeStatsTab
-import eu.kanade.tachiyomi.ui.stats.manga.mangaStatsTab
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -39,14 +37,11 @@ data object StatsTab : Tab {
 
         val tabs = persistentListOf(
             animeStatsTab(),
-            mangaStatsTab(),
         )
-        val state = rememberPagerState { tabs.size }
 
         TabbedScreen(
             titleRes = MR.strings.label_stats,
             tabs = tabs,
-            state = state,
         )
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/storage/StorageTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/storage/StorageTab.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.storage
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
@@ -14,7 +13,6 @@ import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.storage.anime.animeStorageTab
-import eu.kanade.tachiyomi.ui.storage.manga.mangaStorageTab
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -39,14 +37,11 @@ data object StorageTab : Tab {
 
         val tabs = persistentListOf(
             animeStorageTab(),
-            mangaStorageTab(),
         )
-        val state = rememberPagerState { tabs.size }
 
         TabbedScreen(
             titleRes = AYMR.strings.label_storage,
             tabs = tabs,
-            state = state,
         )
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -16,7 +16,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.download.DownloadsTab
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.updates.anime.animeUpdatesTab
-import eu.kanade.tachiyomi.ui.updates.manga.mangaUpdatesTab
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -30,9 +29,8 @@ data object UpdatesTab : Tab {
             val image = AnimatedImageVector.animatedVectorResource(R.drawable.anim_updates_enter)
             val index: UShort = when (currentNavigationStyle()) {
                 NavStyle.MOVE_UPDATES_TO_MORE -> 5u
-                NavStyle.MOVE_HISTORY_TO_MORE -> 2u
-                NavStyle.MOVE_BROWSE_TO_MORE -> 2u
-                NavStyle.MOVE_MANGA_TO_MORE -> 1u
+                NavStyle.MOVE_HISTORY_TO_MORE -> 1u
+                NavStyle.MOVE_BROWSE_TO_MORE -> 1u
             }
             return TabOptions(
                 index = index,
@@ -49,12 +47,11 @@ data object UpdatesTab : Tab {
         val context = LocalContext.current
         val fromMore = currentNavigationStyle() == NavStyle.MOVE_UPDATES_TO_MORE
 
+        val tab = animeUpdatesTab(context, fromMore)
+
         TabbedScreen(
             titleRes = MR.strings.label_recent_updates,
-            tabs = persistentListOf(
-                animeUpdatesTab(context, fromMore),
-                mangaUpdatesTab(context, fromMore),
-            ),
+            tabs = persistentListOf(tab),
         )
 
         LaunchedEffect(Unit) {
@@ -62,6 +59,3 @@ data object UpdatesTab : Tab {
         }
     }
 }
-
-private const val TAB_ANIME = 0
-private const val TAB_MANGA = 1

--- a/app/src/main/java/mihon/core/migration/migrations/NavigationOptionsMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/NavigationOptionsMigration.kt
@@ -26,11 +26,11 @@ class NavigationOptionsMigration : Migration {
             remove("bottom_nav_style")
             remove("default_home_tab_library")
 
-            val startScreen = if (isDefaultTabManga.get()) StartScreen.MANGA else StartScreen.ANIME
+            val startScreen = StartScreen.ANIME
             val navStyle = when (bottomNavStyle.get()) {
                 0 -> NavStyle.MOVE_HISTORY_TO_MORE
                 1 -> NavStyle.MOVE_UPDATES_TO_MORE
-                else -> NavStyle.MOVE_MANGA_TO_MORE
+                else -> NavStyle.MOVE_HISTORY_TO_MORE
             }
 
             preferenceStore.getEnum("start_screen", StartScreen.ANIME).set(startScreen)

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -35,7 +35,7 @@
     <string name="also_set_chapter_settings_for_library">Also apply to all manga in my library</string>
     <string name="dialog_with_checkbox_reset">Reset all chapters for this manga</string>
     <string name="download_insufficient_space">Couldn\'t download due to low storage space</string>
-    <string name="download_queue_size_warning">Warning: large bulk downloads may lead to sources becoming slower and/or blocking Aniyomi. Tap to learn more.</string>
+    <string name="download_queue_size_warning">Warning: large bulk downloads may lead to sources becoming slower and/or blocking WatchAnime. Tap to learn more.</string>
     <string name="pref_invalidate_download_cache_summary">Force app to recheck downloaded chapters and episodes</string>
     <!-- Player settings -->
     <string name="label_player_settings">Player settings</string>
@@ -562,7 +562,7 @@
     <string name="unseen">Unseen</string>
     <string name="label_manga_extension_repos">Manga extension repos</string>
     <string name="label_anime_extension_repos">Anime extension repos</string>
-    <string name="onboarding_storage_action_create_folder">Create default Aniyomi folder</string>
+    <string name="onboarding_storage_action_create_folder">Create default WatchAnime folder</string>
     <string name="download_speed_limit">Chapter download speed limit</string>
     <string name="download_speed_limit_hint">Set to 0 to disable the speed limit.</string>
     <string name="filler">Filler</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Aniyomi</string>
+    <string name="app_name" translatable="false">WatchAnime</string>
 
     <!-- Generic strings -->
     <string name="on">On</string>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,7 @@ plugins {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-rootProject.name = "Aniyomi"
+rootProject.name = "WatchAnime"
 include(":app")
 include(":core-metadata")
 include(":core:archive")


### PR DESCRIPTION
This is a fork of Aniyomi focused exclusively on anime watching.

Changes:
- Rename app to WatchAnime in strings, settings, and README
- Remove MangaLibraryTab from bottom navigation
- Remove manga tabs from Updates, History, Browse, Downloads, Categories, Stats, and Storage screens
- Remove manga reader settings from main settings menu
- Remove manga sources, extensions, and migration from Browse
- Simplify NavStyle enum (remove MOVE_MANGA_TO_MORE)
- Remove MANGA from StartScreen enum
- Clean up HomeScreen tab routing for manga removal
- Update README with fork attribution to Aniyomi